### PR TITLE
Add cubic example

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+PERK = "85f1910e-5d62-11e9-1bce-2b30a05932d4"
 
 [compat]
 Documenter = "0.27"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,7 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-PERK = "85f1910e-5d62-11e9-1bce-2b30a05932d4"
+MIRTjim = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
 
 [compat]
 Documenter = "0.27"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 MIRTjim = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Documenter = "0.27"

--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -43,8 +43,8 @@ using InteractiveUtils: versioninfo
 Although neural networks are very popular,
 low-dimensional nonlinear regression problems
 can be handled quite efficiently
-by kernel regression (KR).
-Training KR does not require iterative algorithms
+by kernel ridge regression (KRR).
+Training KRR does not require iterative algorithms
 and is more interpretable than a deep network.
 It is simply a nonlinear lifting
 followed by ridge regression.
@@ -53,7 +53,7 @@ followed by ridge regression.
 #=
 ### Example
 
-Here is an example of using KR
+Here is an example of using KRR
 to learn the function ``y = x^3``
 from noisy training data.
 =#
@@ -76,7 +76,7 @@ train = PERK.krr_train(ytrain, xtrain, kernel, ρ);
 # and regresses to the mean outside of that range.
 xtest = LinRange(-1, 1, 200) * 4
 yhat = PERK.krr(xtest, train, kernel) # todo: remove kernel eventually
-plot!(p0, xtest, yhat, label="KR prediction", color=:magenta)
+plot!(p0, xtest, yhat, label="KRR prediction", color=:magenta)
 
 
 # The (only!) two parameters ρ and λ can be selected automatically

--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -26,10 +26,12 @@ This page was generated from a single Julia file:
 # Packages needed here.
 
 using PERK
+using MIRTjim: jim, prompt
+using Plots; default(markerstrokecolor = :auto, label="")
 using InteractiveUtils: versioninfo
 
 
-#src The following line is helpful when running this example.jl file as a script;
+#src The following line is helpful when running this file as a script;
 #src this way it will prompt user to hit a key after each figure is displayed.
 
 #src isinteractive() ? jim(:prompt, true) : prompt(:draw);
@@ -38,11 +40,51 @@ using InteractiveUtils: versioninfo
 # ### Overview
 
 #=
-todo
+Although neural networks are very popular,
+low-dimensional nonlinear regression problems
+can be handled quite efficiently
+by kernel regression (KR).
+Training KR does not require iterative algorithms
+and is more interpretable than a deep network.
+It is simply a nonlinear lifting
+followed by ridge regression.
 =#
 
+#=
+### Example
 
-# ## Reproducibility
+Here is an example of using KR
+to learn the function ``y = x^3``
+from noisy training data.
+=#
+
+fun(x) = x^3
+xtrain = LinRange(-1, 1, 101) * 3
+ytrain = fun.(xtrain) + 1 * randn(size(xtrain))
+p0 = scatter(xtrain, ytrain, xlabel="x", ylabel="y", label="training data")
+plot!(p0, fun, label="y = x^3", legend=:top, color=:black)
+
+# Here is the key training step
+ρ = 1e-5
+λ = 0.5
+kernel = GaussianKernel(λ)
+train = PERK.krr_train(ytrain, xtrain, kernel, ρ);
+#src jim(train.K, "PERK K")
+
+# Now examine the fit using (exhaustive) test data.
+# The fit is very good within the range of the training data,
+# and regresses to the mean outside of that range.
+xtest = LinRange(-1, 1, 200) * 4
+yhat = PERK.krr(xtest, train, kernel) # todo: remove kernel eventually
+plot!(p0, xtest, yhat, label="KR prediction", color=:magenta)
+
+
+# The (only!) two parameters ρ and λ can be selected automatically
+# using cross validation.
+# todo: need example here
+
+
+# ### Reproducibility
 
 # This page was generated with the following version of Julia:
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,8 @@
 execute = isempty(ARGS) || ARGS[1] == "run"
 
+#using Pkg
+#Pkg.add(url="https://github.com/StevenWhitaker/PERK.jl")
+
 using PERK
 using Documenter
 using Literate
@@ -70,6 +73,4 @@ if isci
         forcepush = true,
 #       push_preview = true,
     )
-else
-    @warn "may need to: rm -r src/generated/"
 end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,8 +11,13 @@ CurrentModule = PERK
 
 ## Overview
 
-This page will eventually provide documentation for
-[PERK.jl](https://github.com/StevenWhitaker/PERK.jl).
+Skeleton documentation for the Julia package
+[(PERK.jl)](https://github.com/StevenWhitaker/PERK.jl)
+that performs
+parameter estimation with regression with kernels (PERK).
+See
+[IEEE T-MI paper](http://doi.org/10.1109/TMI.2018.2817547)
+for details.
 
 For an extensive use of PERK,
 see


### PR DESCRIPTION
To have at least one illustration of `krr_train` and `krr` for now.